### PR TITLE
feat(open-api): self-describe stage-plan, add clear/replace, fix keyword search

### DIFF
--- a/agent_skills/snowfox-system/references/runtime_capabilities.yaml
+++ b/agent_skills/snowfox-system/references/runtime_capabilities.yaml
@@ -122,6 +122,7 @@ local_open_api:
       - POST /api/v1/gui/prefill-add
       - POST /api/v1/gui/prefill-ai-prompt
       - POST /api/v1/gui/stage-plan
+      - POST /api/v1/gui/stage-plan/clear
   stage_allowed_actions:
     - add
     - edit

--- a/app_gui/application/open_api/contracts.py
+++ b/app_gui/application/open_api/contracts.py
@@ -24,6 +24,141 @@ LOCAL_OPEN_API_SEARCH_MODES = tuple(
     or ("fuzzy", "exact")
 )
 
+# Self-describing per-action payload schema for ``POST /api/v1/gui/stage-plan``.
+# This MIRRORS the runtime validators in ``lib/plan_gate.py``
+# (``_validate_item_payload_schema``); keep the two in sync. A unit test asserts
+# that every key marked ``required`` here is actually enforced by plan_gate.
+LOCAL_OPEN_API_STAGE_PLAN_PAYLOAD_SCHEMA = {
+    "notes": [
+        "Each item has top-level routing keys (action/record_id/box/position/...) "
+        "plus an inner 'payload' object consumed by the GUI plan executor.",
+        "Structural keys that also exist at the item level "
+        "(record_id, box, position, positions, to_position, to_box) may be omitted "
+        "from payload; the API backfills them from the item. Caller-only data "
+        "(fields, stored_at, date_str) is never inferred and must be supplied.",
+        "Payload shapes intentionally differ per action: 'edit' wraps changes under "
+        "'fields'; 'takeout'/'move' use flat keys.",
+    ],
+    "actions": {
+        "add": {
+            "item_keys": {"action": "add", "box": "int>0", "position": "int>0"},
+            "payload": {
+                "box": {"type": "int>0", "required": False, "inherits": "item.box"},
+                "positions": {
+                    "type": "list[int>0]",
+                    "required": True,
+                    "default": "[item.position]",
+                    "note": "must include item.position",
+                },
+                "stored_at": {
+                    "type": "date-string YYYY-MM-DD",
+                    "required": True,
+                    "alias": "frozen_at",
+                },
+                "fields": {"type": "object", "required": True, "note": "may be empty"},
+            },
+            "example": {
+                "action": "add",
+                "box": 1,
+                "position": 2,
+                "source": "api",
+                "payload": {
+                    "positions": [2],
+                    "stored_at": "2024-01-02",
+                    "fields": {"short_name": "clone-a"},
+                },
+            },
+        },
+        "edit": {
+            "item_keys": {"action": "edit", "record_id": "int>0"},
+            "payload": {
+                "record_id": {
+                    "type": "int>0",
+                    "required": False,
+                    "inherits": "item.record_id",
+                },
+                "fields": {
+                    "type": "object",
+                    "required": True,
+                    "note": "non-empty; the fields to change",
+                },
+            },
+            "example": {
+                "action": "edit",
+                "record_id": 7,
+                "source": "api",
+                "payload": {"fields": {"note": "edited"}},
+            },
+        },
+        "takeout": {
+            "item_keys": {"action": "takeout", "record_id": "int>0", "position": "int>0"},
+            "payload": {
+                "record_id": {
+                    "type": "int>0",
+                    "required": False,
+                    "inherits": "item.record_id",
+                },
+                "position": {
+                    "type": "int>0",
+                    "required": False,
+                    "inherits": "item.position",
+                },
+                "date_str": {"type": "date-string YYYY-MM-DD", "required": True},
+            },
+            "example": {
+                "action": "takeout",
+                "record_id": 7,
+                "box": 1,
+                "position": 5,
+                "source": "api",
+                "payload": {"date_str": "2026-02-10"},
+            },
+        },
+        "move": {
+            "item_keys": {
+                "action": "move",
+                "record_id": "int>0",
+                "position": "int>0",
+                "to_position": "int>0",
+                "to_box": "int>0 (optional)",
+            },
+            "payload": {
+                "record_id": {
+                    "type": "int>0",
+                    "required": False,
+                    "inherits": "item.record_id",
+                },
+                "position": {
+                    "type": "int>0",
+                    "required": False,
+                    "inherits": "item.position",
+                },
+                "date_str": {"type": "date-string YYYY-MM-DD", "required": True},
+                "to_position": {
+                    "type": "int>0",
+                    "required": False,
+                    "inherits": "item.to_position",
+                    "note": "must differ from position when target box is unchanged",
+                },
+                "to_box": {
+                    "type": "int>0",
+                    "required": False,
+                    "inherits": "item.to_box",
+                },
+            },
+            "example": {
+                "action": "move",
+                "record_id": 7,
+                "box": 1,
+                "position": 5,
+                "to_position": 10,
+                "source": "api",
+                "payload": {"date_str": "2026-02-10"},
+            },
+        },
+    },
+}
+
 LOCAL_OPEN_API_ROUTE_SPECS = {
     ("GET", "/api/v1/capabilities"): {
         "handler": "_handle_capabilities",
@@ -207,9 +342,27 @@ LOCAL_OPEN_API_ROUTE_SPECS = {
                 "type": "array",
                 "required": True,
                 "accepted_values": sorted(LOCAL_OPEN_API_STAGE_ALLOWED_ACTIONS),
+                "item_payload_schema": "see result.stage_plan_schema in /capabilities",
+            },
+            {
+                "name": "mode",
+                "in": "body",
+                "type": "string",
+                "required": False,
+                "default": "merge",
+                "accepted_values": ["merge", "replace"],
+                "description": "merge (default) dedups into existing staged items; "
+                "replace discards all currently staged items first.",
             },
             {"name": "focus", "in": "body", "type": "boolean", "required": False},
         ],
+    },
+    ("POST", "/api/v1/gui/stage-plan/clear"): {
+        "handler": "_handle_clear_stage_plan",
+        "request_arg": "payload",
+        "effect": "gui_stage_only",
+        "summary": "Clear all currently staged GUI plan items without executing inventory writes.",
+        "params": [],
     },
 }
 

--- a/app_gui/application/open_api/service.py
+++ b/app_gui/application/open_api/service.py
@@ -29,9 +29,76 @@ from .contracts import (
     LOCAL_OPEN_API_ROUTE_ALLOWLIST,
     LOCAL_OPEN_API_ROUTE_SPECS,
     LOCAL_OPEN_API_STAGE_ALLOWED_ACTIONS,
+    LOCAL_OPEN_API_STAGE_PLAN_PAYLOAD_SCHEMA,
     LOCAL_OPEN_API_VALIDATION_MODES,
     iter_local_open_api_route_descriptions,
 )
+
+
+# Client-side guidance surfaced in /capabilities. The server already emits
+# UTF-8 with an explicit charset; mojibake and quoting friction are client
+# decoding/escaping issues (notably Windows PowerShell), so steer callers here.
+_LOCAL_OPEN_API_CLIENT_HINTS = {
+    "encoding": (
+        "All responses are 'application/json; charset=utf-8'. Decode response "
+        "bytes as UTF-8. On Windows PowerShell, Invoke-WebRequest/console may "
+        "mis-decode UTF-8 as the system codepage (e.g. GBK), turning Chinese "
+        "fields like box_tags into mojibake; prefer Invoke-RestMethod, which "
+        "parses JSON as UTF-8."
+    ),
+    "powershell_examples": [
+        "Invoke-RestMethod -Uri http://127.0.0.1:37666/api/v1/capabilities | "
+        "ConvertTo-Json -Depth 8",
+        "$body = @{ items = @(@{ action='edit'; record_id=7; "
+        "payload=@{ fields=@{ note='edited' } } }) } | ConvertTo-Json -Depth 8; "
+        "Invoke-RestMethod -Method Post "
+        "-Uri http://127.0.0.1:37666/api/v1/gui/stage-plan "
+        "-ContentType 'application/json; charset=utf-8' -Body $body",
+        "Invoke-RestMethod -Method Post "
+        "-Uri http://127.0.0.1:37666/api/v1/gui/stage-plan/clear",
+    ],
+    "curl_example": (
+        "Use curl.exe (not the PowerShell alias) and a here-string for JSON: "
+        "curl.exe -s -X POST http://127.0.0.1:37666/api/v1/gui/stage-plan "
+        "-H \"Content-Type: application/json; charset=utf-8\" "
+        "--data-binary '@body.json'"
+    ),
+}
+
+
+def _backfill_plan_payload(item):
+    """Inherit structural payload keys from the item level when omitted.
+
+    The GUI plan executor's contract duplicates routing keys
+    (record_id/box/position/positions/to_position/to_box) inside ``payload``.
+    Callers may now omit the duplicates; we copy them from the item so the
+    shared validators (which cross-check item == payload) still pass. Caller-only
+    data (fields/stored_at/date_str) is never invented.
+    """
+    if not isinstance(item, dict):
+        return item
+    payload = item.get("payload")
+    if not isinstance(payload, dict):
+        return item
+    action = str(item.get("action") or "").lower()
+
+    def _inherit(payload_key, item_key):
+        if payload.get(payload_key) in (None, "") and item.get(item_key) not in (None, ""):
+            payload[payload_key] = item.get(item_key)
+
+    if action == "add":
+        _inherit("box", "box")
+        if not payload.get("positions") and item.get("position") not in (None, ""):
+            payload["positions"] = [item.get("position")]
+    elif action == "edit":
+        _inherit("record_id", "record_id")
+    elif action in ("takeout", "move"):
+        _inherit("record_id", "record_id")
+        _inherit("position", "position")
+        if action == "move":
+            _inherit("to_position", "to_position")
+            _inherit("to_box", "to_box")
+    return item
 
 
 def _response_envelope(*, ok: bool, message: str = "", result=None, error_code=None, **extra):
@@ -333,8 +400,10 @@ class LocalOpenApiController:
                 },
                 "validation_modes": list(LOCAL_OPEN_API_VALIDATION_MODES),
                 "stage_allowed_actions": sorted(LOCAL_OPEN_API_STAGE_ALLOWED_ACTIONS),
+                "stage_plan_schema": copy.deepcopy(LOCAL_OPEN_API_STAGE_PLAN_PAYLOAD_SCHEMA),
                 "dataset_schema": dataset_schema,
                 "response_shapes": build_inventory_response_shapes_payload(),
+                "client_hints": copy.deepcopy(_LOCAL_OPEN_API_CLIENT_HINTS),
                 "routes": list(iter_local_open_api_route_descriptions(sort_routes=True)),
             },
         )
@@ -779,11 +848,24 @@ class LocalOpenApiController:
                 )
             item["action"] = action
             item.setdefault("source", "api")
+            _backfill_plan_payload(item)
             normalized_items.append(item)
 
+        mode = str(body.get("mode") or "merge").strip().lower()
+        if mode not in ("merge", "replace"):
+            return _error_response(
+                status_code=400,
+                error_code="invalid_request",
+                message="mode must be 'merge' or 'replace'.",
+                field="mode",
+                expected_type="string",
+                accepted_values=["merge", "replace"],
+            )
+
         yaml_path = self._current_yaml_path(must_exist=True)
+        existing_for_gate = [] if mode == "replace" else self._plan_store.list_items()
         gate = validate_stage_request(
-            existing_items=self._plan_store.list_items(),
+            existing_items=existing_for_gate,
             incoming_items=normalized_items,
             yaml_path=yaml_path,
             bridge=self._bridge,
@@ -804,7 +886,9 @@ class LocalOpenApiController:
 
         accepted = list(gate.get("accepted_items") or [])
         noop_items = list(gate.get("noop_items") or [])
-        if accepted:
+        if mode == "replace":
+            self._plan_store.replace_all(accepted)
+        elif accepted:
             self._plan_store.add(accepted)
 
         focus = _coerce_bool(body.get("focus"), default=True)
@@ -820,8 +904,9 @@ class LocalOpenApiController:
             executed=False,
             staged=True,
             inventory_written=False,
-            gui_changed=bool(accepted or noop_items or focus),
+            gui_changed=bool(accepted or noop_items or focus or mode == "replace"),
             result={
+                "mode": mode,
                 "staged_count": len(accepted),
                 "already_staged_count": len(noop_items),
                 "total_count": self._plan_store.count(),
@@ -829,6 +914,28 @@ class LocalOpenApiController:
                 "noop_items": noop_items,
                 "focused": focus,
                 "stats": gate.get("stats") if isinstance(gate.get("stats"), dict) else {},
+            },
+        )
+
+    def _handle_clear_stage_plan(self, payload):
+        if self._plan_store is None:
+            return 500, _response_envelope(
+                ok=False,
+                error_code="plan_store_unavailable",
+                message="Plan store is unavailable.",
+            )
+        cleared = self._plan_store.clear()
+        return 200, _response_envelope(
+            ok=True,
+            message="Cleared staged GUI plan",
+            effect="gui_stage_only",
+            executed=False,
+            staged=False,
+            inventory_written=False,
+            gui_changed=bool(cleared),
+            result={
+                "cleared_count": len(cleared),
+                "total_count": self._plan_store.count(),
             },
         )
 

--- a/lib/inventory_query_contracts.py
+++ b/lib/inventory_query_contracts.py
@@ -20,7 +20,9 @@ SEARCH_QUERY_DESCRIPTION = (
 
 SEARCH_MODE_DESCRIPTION = (
     "Search strategy over separator-normalized text: "
-    "fuzzy = substring match, keywords = AND-token match, "
+    "fuzzy = whole-text substring match, "
+    "keywords = AND-match where each token is a substring of some record token "
+    "(so 'sg' matches 'sg2'), "
     "exact = scalar equality against one normalized field value."
 )
 

--- a/lib/tool_api_impl/read_ops.py
+++ b/lib/tool_api_impl/read_ops.py
@@ -309,7 +309,7 @@ def tool_search_records(
                 continue
 
             record_tokens = api.record_search_tokens(rec, case_sensitive=case_sensitive)
-            if keywords and all(kw in record_tokens for kw in keywords):
+            if api.keywords_match(record_tokens, keywords):
                 matches.append(rec)
     elif has_structured_filter or not normalized_query:
         matches = list(scoped_records)

--- a/lib/tool_api_parsers.py
+++ b/lib/tool_api_parsers.py
@@ -350,6 +350,18 @@ def record_search_tokens(record, case_sensitive=False):
     return tokens
 
 
+def keywords_match(record_tokens, keywords):
+    """AND-match each keyword as a substring of at least one record token.
+
+    Keeps token boundaries (unlike whole-blob ``fuzzy``) while still matching
+    short or suffixed tokens, e.g. keyword ``sg`` matches record token ``sg2``
+    so a query like ``NT-sg`` -> ``[nt, sg]`` hits a ``NT-sg2`` field.
+    """
+    if not keywords:
+        return False
+    return all(any(kw in token for token in record_tokens) for kw in keywords)
+
+
 def parse_search_location_shortcut(query_text, layout):
     """Parse compact location query like ``2:15`` into (box, position)."""
     text = str(query_text or "").strip()
@@ -391,4 +403,5 @@ _record_search_blob = record_search_blob
 _normalize_search_text = normalize_search_text
 _record_search_values = record_search_values
 _record_search_tokens = record_search_tokens
+_keywords_match = keywords_match
 _parse_search_location_shortcut = parse_search_location_shortcut

--- a/lib/tool_api_support.py
+++ b/lib/tool_api_support.py
@@ -91,6 +91,7 @@ record_search_blob = _parsers.record_search_blob
 normalize_search_text = _parsers.normalize_search_text
 record_search_values = _parsers.record_search_values
 record_search_tokens = _parsers.record_search_tokens
+keywords_match = _parsers.keywords_match
 parse_search_location_shortcut = _parsers.parse_search_location_shortcut
 
 

--- a/tests/contract/test_tool_contracts_single_source.py
+++ b/tests/contract/test_tool_contracts_single_source.py
@@ -293,7 +293,8 @@ class ToolContractsSingleSourceTests(unittest.TestCase):
         self.assertIn("spaces, hyphens, and underscores", query_description)
         self.assertIn("empty or '*'", query_description)
         self.assertIn("separator-normalized text", mode_description)
-        self.assertIn("keywords = AND-token match", mode_description)
+        self.assertIn("keywords = AND-match", mode_description)
+        self.assertIn("substring of some record token", mode_description)
 
 
 class PlanItemTypeTests(unittest.TestCase):

--- a/tests/integration/gui/test_local_open_api.py
+++ b/tests/integration/gui/test_local_open_api.py
@@ -443,6 +443,103 @@ class LocalOpenApiTests(ManagedPathTestCase):
         self.assertEqual("plan_action_not_allowed", payload["error_code"])
         self.assertEqual(["add", "edit", "move", "takeout"], payload["accepted_values"])
 
+    def test_capabilities_exposes_stage_plan_schema_and_client_hints(self):
+        status, payload = self.controller.handle_request("GET", "/api/v1/capabilities", {})
+        self.assertEqual(200, status)
+        result = payload["result"]
+
+        schema = result["stage_plan_schema"]
+        self.assertEqual({"add", "edit", "takeout", "move"}, set(schema["actions"].keys()))
+        # edit wraps changes under fields; takeout/move are flat — both documented.
+        self.assertIn("fields", schema["actions"]["edit"]["payload"])
+        self.assertIn("date_str", schema["actions"]["takeout"]["payload"])
+        self.assertNotIn("fields", schema["actions"]["takeout"]["payload"])
+
+        hints = result["client_hints"]
+        self.assertIn("utf-8", hints["encoding"].lower())
+        self.assertTrue(
+            any("Invoke-RestMethod" in example for example in hints["powershell_examples"])
+        )
+
+    def test_stage_plan_clear_route_empties_store(self):
+        item = build_add_plan_item(
+            box=1, positions=[2], stored_at="2024-01-02", fields={}, source="api-test"
+        )
+        status, _ = self.controller.handle_request(
+            "POST", "/api/v1/gui/stage-plan", {}, payload={"items": [item]}
+        )
+        self.assertEqual(200, status)
+        self.assertEqual(1, self.plan_store.count())
+
+        status, payload = self.controller.handle_request(
+            "POST", "/api/v1/gui/stage-plan/clear", {}, payload=None
+        )
+        self.assertEqual(200, status)
+        self.assertTrue(payload["ok"])
+        self.assertEqual(1, payload["result"]["cleared_count"])
+        self.assertEqual(0, payload["result"]["total_count"])
+        self.assertEqual(0, self.plan_store.count())
+        self.assertEqual("gui_stage_only", payload["effect"])
+        self.assertFalse(payload["inventory_written"])
+
+    def test_stage_plan_replace_mode_discards_existing_items(self):
+        first = build_add_plan_item(
+            box=1, positions=[2], stored_at="2024-01-02", fields={}, source="api-test"
+        )
+        self.controller.handle_request(
+            "POST", "/api/v1/gui/stage-plan", {}, payload={"items": [first]}
+        )
+        self.assertEqual(1, self.plan_store.count())
+
+        second = build_add_plan_item(
+            box=1, positions=[3], stored_at="2024-01-02", fields={}, source="api-test"
+        )
+        status, payload = self.controller.handle_request(
+            "POST",
+            "/api/v1/gui/stage-plan",
+            {},
+            payload={"items": [second], "mode": "replace"},
+        )
+        self.assertEqual(200, status, payload)
+        self.assertTrue(payload["ok"], payload)
+        self.assertEqual("replace", payload["result"]["mode"])
+        self.assertEqual(1, self.plan_store.count())
+        remaining = self.plan_store.list_items()
+        self.assertEqual([3], remaining[0]["payload"]["positions"])
+
+    def test_stage_plan_rejects_invalid_mode(self):
+        item = build_add_plan_item(
+            box=1, positions=[2], stored_at="2024-01-02", fields={}, source="api-test"
+        )
+        status, payload = self.controller.handle_request(
+            "POST",
+            "/api/v1/gui/stage-plan",
+            {},
+            payload={"items": [item], "mode": "bogus"},
+        )
+        self.assertEqual(400, status)
+        self.assertFalse(payload["ok"])
+        self.assertEqual("invalid_request", payload["error_code"])
+        self.assertEqual("mode", payload["field"])
+
+    def test_stage_plan_backfills_omitted_payload_keys(self):
+        # payload omits box and positions; they are inherited from the item level.
+        item = {
+            "action": "add",
+            "box": 1,
+            "position": 4,
+            "payload": {"stored_at": "2024-01-02", "fields": {}},
+        }
+        status, payload = self.controller.handle_request(
+            "POST", "/api/v1/gui/stage-plan", {}, payload={"items": [item]}
+        )
+        self.assertEqual(200, status, payload)
+        self.assertTrue(payload["ok"], payload)
+        self.assertEqual(1, payload["result"]["staged_count"])
+        staged = self.plan_store.list_items()[0]
+        self.assertEqual(1, staged["payload"]["box"])
+        self.assertEqual([4], staged["payload"]["positions"])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/integration/inventory/test_tool_api.py
+++ b/tests/integration/inventory/test_tool_api.py
@@ -989,6 +989,47 @@ class ToolApiTests(ManagedPathTestCase):
             self.assertTrue(underscored["ok"])
             self.assertEqual([1], [item["id"] for item in underscored["result"]["records"]])
 
+    def test_tool_search_records_keywords_matches_suffixed_token(self):
+        # A short, hyphenated query (NT-sg -> [nt, sg]) should still match a
+        # record whose field carries an extra suffix (NT-sg2 -> tokens nt/sg2),
+        # matching what fuzzy already finds. Regression for keyword exact-token gap.
+        with tempfile.TemporaryDirectory(prefix="ln2_tool_search_kw_suffix_") as temp_dir:
+            yaml_path = Path(temp_dir) / "inventory.yaml"
+            write_yaml(
+                make_data(
+                    [
+                        {
+                            "id": 1,
+                            "parent_cell_line": "K562",
+                            "short_name": "NT-sg2",
+                            "box": 1,
+                            "position": 1,
+                            "frozen_at": "2025-01-01",
+                        },
+                        {
+                            "id": 2,
+                            "parent_cell_line": "K562",
+                            "short_name": "control",
+                            "box": 1,
+                            "position": 2,
+                            "frozen_at": "2025-01-01",
+                        },
+                    ]
+                ),
+                path=str(yaml_path),
+                audit_meta={"action": "seed", "source": "tests"},
+            )
+
+            keywords = tool_search_records(str(yaml_path), query="NT-sg", mode="keywords")
+            fuzzy = tool_search_records(str(yaml_path), query="NT-sg", mode="fuzzy")
+
+            self.assertTrue(keywords["ok"])
+            self.assertEqual([1], [item["id"] for item in keywords["result"]["records"]])
+            self.assertEqual(
+                [item["id"] for item in fuzzy["result"]["records"]],
+                [item["id"] for item in keywords["result"]["records"]],
+            )
+
     def test_tool_search_records_exact_matches_normalized_scalar_values_only(self):
         with tempfile.TemporaryDirectory(prefix="ln2_tool_search_exact_") as temp_dir:
             yaml_path = Path(temp_dir) / "inventory.yaml"

--- a/tests/unit/test_local_open_api_contracts.py
+++ b/tests/unit/test_local_open_api_contracts.py
@@ -1,7 +1,12 @@
+import copy
+
 from app_gui.application.open_api.contracts import (
+    LOCAL_OPEN_API_STAGE_PLAN_PAYLOAD_SCHEMA,
     describe_local_open_api_route,
     iter_local_open_api_route_descriptions,
 )
+from app_gui.application.open_api.service import _backfill_plan_payload
+from lib.plan_gate import _validate_item_payload_schema
 
 
 def test_describe_local_open_api_route_projects_public_fields_from_contract():
@@ -24,3 +29,28 @@ def test_iter_local_open_api_route_descriptions_returns_defensive_copies():
 
     assert all(param.get("name") != "mutated" for param in fresh["params"])
     assert fresh["effect"] == "gui_stage_state"
+
+
+def test_stage_plan_schema_required_keys_match_plan_gate_enforcement():
+    # Drift guard: the documented schema must stay in lock-step with the runtime
+    # validators in lib/plan_gate.py. For every action, the documented example
+    # validates cleanly, and removing any payload key marked required must make
+    # plan_gate reject the item.
+    actions = LOCAL_OPEN_API_STAGE_PLAN_PAYLOAD_SCHEMA["actions"]
+    for action, spec in actions.items():
+        example = _backfill_plan_payload(copy.deepcopy(spec["example"]))
+        assert _validate_item_payload_schema(example) is None, (action, "baseline must validate")
+
+        required_keys = [key for key, meta in spec["payload"].items() if meta.get("required")]
+        assert required_keys, (action, "must document at least one required key")
+        for key in required_keys:
+            broken = _backfill_plan_payload(copy.deepcopy(spec["example"]))
+            broken["payload"].pop(key, None)
+            alias = spec["payload"][key].get("alias")
+            if alias:
+                broken["payload"].pop(alias, None)
+            assert _validate_item_payload_schema(broken) is not None, (
+                action,
+                key,
+                "removing a required key must be rejected",
+            )


### PR DESCRIPTION
## Context

Addresses structured developer feedback on the loopback **local Open API**. The praise was for the self-describing `/capabilities` surface and the clean read/stage/execute boundary; the complaints were concrete and verified against the code. This PR fixes the actionable ones without breaking the GUI/agent consumers of the plan-item shape.

## Changes

- **Self-describing stage-plan payloads** — `/capabilities` now returns `result.stage_plan_schema`, documenting each action's payload (required/optional keys, types, inheritance, examples). Mirrors the `lib/plan_gate.py` validators; a drift-guard test keeps them in lock-step. This also makes the intentional `edit` (`fields:{}` wrapper) vs `takeout`/`move` (flat) difference explicit instead of trial-and-error.
- **Clear + replace** — new `POST /api/v1/gui/stage-plan/clear` and a `mode=replace` option on `POST /stage-plan`, closing the "merge-only, no undo" gap. Reuses `PlanStore.clear()` / `replace_all()`.
- **Redundant payload keys optional** — structural keys (`record_id`/`box`/`position`/`positions`/`to_position`/`to_box`) are backfilled from the item level when omitted. Validators unchanged; full-payload clients unaffected.
- **Keyword search fix** — `keywords` mode now matches each token as a substring of a record token (shared `keywords_match` helper), so `NT-sg` hits `NT-sg2` like `fuzzy` does. Search-mode contract description updated.
- **Client hints** — `/capabilities` adds `client_hints` with UTF-8 + PowerShell/`curl.exe` guidance. **No server encoding change** — the server already emits correct UTF-8; the reported mojibake is client-side decoding (PowerShell/GBK).
- Synced the in-repo `runtime_capabilities.yaml` catalog with the new route.

## Module classification

Cross-module (`gui_application/open_api` + `inventory_core`). The keyword-match change is a shared bottleneck — Tool API, agent runtime, and GUI search all route through `tool_search_records`, so the fix is single-source.

## Documented, not changed

The `edit`/`takeout` payload-shape inconsistency is shared with the GUI + agent via `plan_item_factory`; restructuring would be a contract break, so it's documented via the new schema rather than altered.

## Testing

- Added/extended: capabilities schema + client_hints, clear route, replace mode, invalid-mode rejection, payload backfill, `NT-sg` keyword-vs-fuzzy parity, and a drift-guard tying the documented schema to `plan_gate` enforcement.
- Full suite: **1999 passed, 1 failed**. The single failure (`test_add_rejects_mixed_declared_and_undeclared_fields`) is **pre-existing and unrelated** — confirmed by reproducing it with these changes stashed on clean `main`; it lives in the add/field-validation path this PR doesn't touch.

## Follow-up (out of repo scope)

The developer-facing `snowfox-local-api` skill (in `~/.claude/skills`) should be updated to mirror the new `stage_plan_schema`, clear/replace routes, and PowerShell hints.

🤖 Generated with [Claude Code](https://claude.com/claude-code)